### PR TITLE
Improve property extraction for cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ You can access the plugin directly from the Figma community - [Link to plugin](h
 
 # Figma To Cursor Plugin
 
-This plugin allows you to copy all the properties of any group or frame and its child layers in Figma, enabling easy recreation in code using Cursor.
+This plugin allows you to copy all the properties of any group or frame and its child layers in Figma, enabling easy recreation in code using Cursor. The property extraction now captures more styling details (fills, strokes, auto layout, text styles, etc.) so pasted JSON replicates the original design more accurately.
 
 ## Installation
 

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -1,7 +1,7 @@
 figma.showUI(__html__, { width: 400, height: 300 });
 
 function extractProperties(node: SceneNode) {
-  return {
+  const props: Record<string, any> = {
     id: node.id,
     name: node.name,
     type: node.type,
@@ -9,7 +9,66 @@ function extractProperties(node: SceneNode) {
     y: node.y,
     width: node.width,
     height: node.height,
+    rotation: node.rotation,
+    opacity: node.opacity,
+    visible: node.visible,
   };
+
+  if ('fills' in node && node.fills !== figma.mixed) {
+    props.fills = node.fills;
+  }
+
+  if ('strokes' in node && node.strokes !== figma.mixed) {
+    props.strokes = node.strokes;
+    props.strokeWeight = (node as GeometryMixin & SceneNode).strokeWeight;
+  }
+
+  if ('cornerRadius' in node) {
+    const cornerNode = node as GeometryMixin & CornerMixin;
+    if (typeof cornerNode.cornerRadius === 'number') {
+      props.cornerRadius = cornerNode.cornerRadius;
+    } else {
+      props.cornerRadius = {
+        topLeft: cornerNode.topLeftRadius,
+        topRight: cornerNode.topRightRadius,
+        bottomLeft: cornerNode.bottomLeftRadius,
+        bottomRight: cornerNode.bottomRightRadius,
+      };
+    }
+  }
+
+  if ('effects' in node) {
+    props.effects = node.effects;
+  }
+
+  if ('constraints' in node) {
+    props.constraints = node.constraints;
+  }
+
+  if ('layoutMode' in node) {
+    const layoutNode = node as FrameNode;
+    props.layoutMode = layoutNode.layoutMode;
+    props.primaryAxisSizingMode = layoutNode.primaryAxisSizingMode;
+    props.counterAxisSizingMode = layoutNode.counterAxisSizingMode;
+    props.itemSpacing = layoutNode.itemSpacing;
+    props.paddingLeft = layoutNode.paddingLeft;
+    props.paddingRight = layoutNode.paddingRight;
+    props.paddingTop = layoutNode.paddingTop;
+    props.paddingBottom = layoutNode.paddingBottom;
+  }
+
+  if (node.type === 'TEXT') {
+    const textNode = node as TextNode;
+    props.characters = textNode.characters;
+    props.fontName = textNode.fontName;
+    props.fontSize = textNode.fontSize;
+    props.textAlignHorizontal = textNode.textAlignHorizontal;
+    props.textAlignVertical = textNode.textAlignVertical;
+    props.lineHeight = textNode.lineHeight;
+    props.letterSpacing = textNode.letterSpacing;
+  }
+
+  return props;
 }
 
 function collectNodeProperties(node: SceneNode): any {


### PR DESCRIPTION
## Summary
- capture more Figma node properties when copying
- mention more accurate replication in README

## Testing
- `yarn build` *(fails: package missing from lockfile)*
- `npx tsc --noEmit` *(fails: cannot find module errors)*